### PR TITLE
Add speech fallback for Safari

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 google-genai
 pydantic>=2
 numpy
+SpeechRecognition


### PR DESCRIPTION
## Summary
- add SpeechRecognition dependency
- add audio transcription endpoint with FFmpeg conversion
- record audio with MediaRecorder when SpeechRecognition is missing

## Testing
- `python -m py_compile server.py`
- `node --check static/app.js`

------
https://chatgpt.com/codex/tasks/task_e_684a8d30c248832bac9813ca7b45371f